### PR TITLE
Ensure position of follower is correct on window load. Starts follower at 0px width.

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -85,7 +85,7 @@ export default Ember.Component.extend({
     this._super(...arguments);
 
     this._assertChildrenMatchSelector();
-    this.nextRun = next(this, this._moveFollower, false);
+    this._ensureCorrectInitialPosition();
   },
 
   willDestroy() {
@@ -94,6 +94,35 @@ export default Ember.Component.extend({
     removeListener(this.router, 'willTransition', this, this._queueMoveFollower);
     cancel(this.nextRun);
     this.router = null;
+  },
+
+  /**
+   * Ensures the position of the follower is correct.
+   *
+   * @private
+   */
+  _ensureCorrectInitialPosition() {
+    this._ensureCorrectPositionOnNextRun();
+    this._ensureCorrectPositionOnWindowLoad();
+  },
+
+  /**
+   * Ensures the position of the follower on the next run.
+   *
+   * @private
+   */
+  _ensureCorrectPositionOnNextRun() {
+    this.nextRun = next(this, this._moveFollower, false);
+  },
+
+  /**
+   * Ensures the initial position of the follower is correct, even if font or
+   * image assets are slow to load.
+   *
+   * @private
+   */
+  _ensureCorrectPositionOnWindowLoad() {
+    window.onload = () => this._moveFollower(false);
   },
 
   /**

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -13,6 +13,6 @@
   border-bottom: 2px solid black;
   position: absolute;
   bottom: 0;
-  width: 150px;
+  width: 0px;
   padding: 0 !important;
 }


### PR DESCRIPTION
- Ensure the correct position of follower if the `window.onload` event
  fires. This ensures the follower position is correct, even if fonts are
  slow to load.
- Start follower at 0px width rather than a random 150px.
