### PR TITLE
Ensures getowner-polyfill installs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "2.2.0",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1",
@@ -60,6 +59,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
+    "ember-getowner-polyfill": "1.0.1",
     "yuidoc-ember-theme": "github:offirgolan/yuidoc-ember-theme"
   },
   "ember-addon": {


### PR DESCRIPTION
When installing the addon, we need to ensure the consuming application installs the `ember-getowner-polyfill`. We use this addon to do a [lookup](https://github.com/echobind/ember-links-with-follower/blob/1cf29252f52c6cfa80ac50930984982baa8455a5/addon/components/links-with-follower.js#L80) for the router and attach an event handler on the willTransition hook when using the `{{link-with-follower}}` component.
## Changes
- Moves `ember-getowner-polyfill` to dependencies
## Testing
- [ ] Automated tests
- [x] Manually tested

Fixes #79 
