### PR TITLE
Adds tests for positioning, width and inactive link

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -62,7 +62,7 @@ export default Ember.Component.extend({
    * @type {Number}
    * @default 150
    */
-  followerAnimationDuration: 150,
+  followerAnimationDuration: (Ember.testing) ? 0 : 150,
 
   /**
    * Where to position the follower. Not yet used.

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -5,8 +5,10 @@ import { isEmpty } from 'ember-utils';
 import { assert } from 'ember-metal/utils';
 import { A as emberArray } from 'ember-array/utils';
 import { addListener, removeListener } from 'ember-metal/events';
+import computed from 'ember-computed';
 import jQuery from 'jquery';
 import getOwner from 'ember-getowner-polyfill';
+import Configuration from '../configuration';
 
 /**
  * A component that renders a follower line underneath provided "links".
@@ -62,7 +64,11 @@ export default Ember.Component.extend({
    * @type {Number}
    * @default 150
    */
-  followerAnimationDuration: (Ember.testing) ? 0 : 150,
+  followerAnimationDuration: computed({
+    get() {
+      return Configuration.followerAnimationDuration;
+    }
+  }),
 
   /**
    * Where to position the follower. Not yet used.

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+const { getWithDefault, typeOf } = Ember;
+
+const DEFAULTS = {
+  followerAnimationDuration: 150
+};
+
+export default {
+  followerAnimationDuration: DEFAULTS.followerAnimationDuration,
+
+  load(config) {
+    for (let property in this) {
+      if (this._hasProperty(property)) {
+        this[property] = getWithDefault(config, property, DEFAULTS[property]);
+      }
+    }
+  },
+
+  _hasProperty(prop) {
+    return this.hasOwnProperty(prop) && typeOf(this[prop]) !== 'function';
+  }
+};

--- a/addon/configuration.js
+++ b/addon/configuration.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
-const { getWithDefault, typeOf } = Ember;
+const { getWithDefault, testing, typeOf } = Ember;
 
 const DEFAULTS = {
-  followerAnimationDuration: 150
+  followerAnimationDuration: testing ? 0 : 150
 };
 
 export default {

--- a/app/initializers/ember-links-with-follower.js
+++ b/app/initializers/ember-links-with-follower.js
@@ -1,0 +1,12 @@
+import ENV from '../config/environment';
+import Configuration from 'ember-links-with-follower/configuration';
+
+export function initialize() {
+  const config = ENV['ember-links-with-follower'] || {};
+  Configuration.load(config);
+}
+
+export default {
+  name: 'ember-links-with-follower',
+  initialize
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('page1');
   this.route('page2');
+  this.route('page3');
 });
 
 export default Router;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -32,10 +32,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
-    ENV['ember-links-with-follower'] = {
-      followerAnimationDuration: 0
-    };
-
     // Testem prefers this...
     ENV.locationType = 'none';
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -32,6 +32,10 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
+    ENV['ember-links-with-follower'] = {
+      followerAnimationDuration: 0
+    };
+
     // Testem prefers this...
     ENV.locationType = 'none';
 

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -86,7 +86,19 @@ describeComponent(
     });
 
     describe('no active link', function() {
-      it.skip('hides the follower');
+      beforeEach(function() {
+        this.render(hbs`
+          {{#links-with-follower linkTagName='div'}}
+            <div>one</div>
+            <div>two</div>
+            <div>three</div>
+          {{/links-with-follower}}
+        `);
+      });
+
+      it('hides the follower', function() {
+        expect(this.$('li.link-follower').is(':visible')).not.to.be.ok;
+      });
     });
   }
 );

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -105,7 +105,7 @@ describeComponent(
       it('moves follower to the active link position', function(done) {
         let $follower = this.$('.link-follower');
 
-        run.later(() => {
+        run.next(() => {
           expect($follower.position().left).to.equal(this.$('.active').position().left);
 
           run(() => {
@@ -116,13 +116,13 @@ describeComponent(
 
           expect($follower.position().left).to.equal(this.$('.active').position().left);
           done();
-        }, 10);
+        });
       });
 
       it('changes width of follower to width of active link', function(done) {
         let $follower = this.$('.link-follower');
 
-        run.later(() => {
+        run.next(() => {
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
 
           run(() => {
@@ -134,7 +134,7 @@ describeComponent(
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
 
           done();
-        }, 10);
+        });
       });
     });
 

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -25,8 +25,6 @@ describeComponent(
   function() {
     describe('default usage', function() {
       beforeEach(function() {
-        Configuration.load({  followerAnimationDuration: 0 });
-
         this.render(hbs`
           {{#links-with-follower}}
             <li>One</li>
@@ -92,6 +90,8 @@ describeComponent(
       let router;
 
       beforeEach(function() {
+        Configuration.load({  followerAnimationDuration: 0 });
+
         this.register('router:main', Ember.Object.extend(Ember.Evented));
 
         router = this.container.lookup('router:main');
@@ -108,17 +108,17 @@ describeComponent(
       it('moves follower to the active link position', function(done) {
         let $follower = this.$('.link-follower');
 
-        run.later(function() {
+        run.later(() => {
           expect($follower.position().left).to.equal(this.$('.active').position().left);
         }, 10);
 
-        run.later(function() {
+        run.later(() => {
           this.$('.active').removeClass('active');
           this.$('.long').addClass('active');
           router.trigger('willTransition');
         }, 20);
 
-        run.later(function() {
+        run.later(() => {
           expect($follower.position().left).to.equal(this.$('.active').position().left);
           done();
         }, 30);
@@ -127,17 +127,17 @@ describeComponent(
       it('changes width of follower to width of active link', function(done) {
         let $follower = this.$('.link-follower');
 
-        run.later(function() {
+        run.later(() => {
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
         }, 10);
 
-        run.later(function() {
+        run.later(() => {
           this.$('.active').removeClass('active');
           this.$('.long').addClass('active');
           router.trigger('willTransition');
         }, 20);
 
-        run.later(function() {
+        run.later(() => {
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
           done();
         }, 30);

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -10,6 +10,7 @@ import {
   describe
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+import Configuration from 'ember-links-with-follower/configuration';
 
 const {
   run
@@ -24,6 +25,8 @@ describeComponent(
   function() {
     describe('default usage', function() {
       beforeEach(function() {
+        Configuration.load({  followerAnimationDuration: 0 });
+
         this.render(hbs`
           {{#links-with-follower}}
             <li>One</li>

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -10,7 +10,6 @@ import {
   describe
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
-import Configuration from 'ember-links-with-follower/configuration';
 
 const {
   run
@@ -90,8 +89,6 @@ describeComponent(
       let router;
 
       beforeEach(function() {
-        Configuration.load({  followerAnimationDuration: 0 });
-
         this.register('router:main', Ember.Object.extend(Ember.Evented));
 
         router = this.container.lookup('router:main');

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -110,18 +110,16 @@ describeComponent(
 
         run.later(() => {
           expect($follower.position().left).to.equal(this.$('.active').position().left);
-        }, 10);
 
-        run.later(() => {
-          this.$('.active').removeClass('active');
-          this.$('.long').addClass('active');
-          router.trigger('willTransition');
-        }, 20);
+          run(() => {
+            this.$('.active').removeClass('active');
+            this.$('.long').addClass('active');
+            router.trigger('willTransition');
+          });
 
-        run.later(() => {
           expect($follower.position().left).to.equal(this.$('.active').position().left);
           done();
-        }, 30);
+        }, 10);
       });
 
       it('changes width of follower to width of active link', function(done) {
@@ -129,18 +127,17 @@ describeComponent(
 
         run.later(() => {
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
-        }, 10);
 
-        run.later(() => {
-          this.$('.active').removeClass('active');
-          this.$('.long').addClass('active');
-          router.trigger('willTransition');
-        }, 20);
+          run(() => {
+            this.$('.active').removeClass('active');
+            this.$('.long').addClass('active');
+            router.trigger('willTransition');
+          });
 
-        run.later(() => {
           expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
+
           done();
-        }, 30);
+        }, 10);
       });
     });
 

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -1,4 +1,5 @@
 /* jshint expr:true */
+import Ember from 'ember';
 import { expect } from 'chai';
 import {
   describeComponent,
@@ -9,6 +10,10 @@ import {
   describe
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+
+const {
+  run
+} = Ember;
 
 describeComponent(
   'links-with-follower',
@@ -81,8 +86,59 @@ describeComponent(
     });
 
     describe('clicking a link', function() {
-      it.skip('moves follower to the active link position')
-      it.skip('changes width of follower to width of active link');
+      let router;
+
+      beforeEach(function() {
+        this.register('router:main', Ember.Object.extend(Ember.Evented));
+
+        router = this.container.lookup('router:main');
+
+        this.render(hbs`
+          {{#links-with-follower class="icon-nav"}}
+            <li class="active">One</li>
+            <li>Two</li>
+            <li class="long">Three Four Five Six</li>
+          {{/links-with-follower}}
+        `);
+      });
+
+      it('moves follower to the active link position', function(done) {
+        let $follower = this.$('.link-follower');
+
+        run.later(function() {
+          expect($follower.position().left).to.equal(this.$('.active').position().left);
+        }, 10);
+
+        run.later(function() {
+          this.$('.active').removeClass('active');
+          this.$('.long').addClass('active');
+          router.trigger('willTransition');
+        }, 20);
+
+        run.later(function() {
+          expect($follower.position().left).to.equal(this.$('.active').position().left);
+          done();
+        }, 30);
+      });
+
+      it('changes width of follower to width of active link', function(done) {
+        let $follower = this.$('.link-follower');
+
+        run.later(function() {
+          expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
+        }, 10);
+
+        run.later(function() {
+          this.$('.active').removeClass('active');
+          this.$('.long').addClass('active');
+          router.trigger('willTransition');
+        }, 20);
+
+        run.later(function() {
+          expect($follower.outerWidth()).to.equal(this.$('.active').outerWidth());
+          done();
+        }, 30);
+      });
     });
 
     describe('no active link', function() {


### PR DESCRIPTION
Adds tests to ensure:

- proper positioning of follower
- animation of width change of follower
- follower does not appear if there are no active links

## Changes

- Adds a check for `Ember.testing` for the `followerAnimationDuration`. Setting it to 0 during testing and a default of 150ms otherwise.

## Testing

- [x] Automated testing
- [x] Manually tested

Fixes #46 