### PR TITLE
Implements CSS based animation for follower

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This pattern is commonly used for navigation:
 
 (from LinkedIn app)
 
+Animation of the follower is done through CSS [transition](https://developer.mozilla.org/en-US/docs/Web/CSS/transition) and [transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform) using [translate3d](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate3d()). The transitions duration will be set to 0 on window resize to avoid issues with animating while resizing.
+
 If your app uses [Velocity.js](http://julian.com/research/velocity) (included with Liquid Fire), it will be used for animating position and size. Otherwise, jQuery's [animate](http://api.jquery.com/animate) will be used.
 
 Since Links with Follower hooks in to the Router's `willTransition` event, you can use `link-to` or `transitionTo` and the follower will still update properly.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ This pattern is commonly used for navigation:
 
 Animation of the follower is done through CSS [transition](https://developer.mozilla.org/en-US/docs/Web/CSS/transition) and [transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform) using [translate3d](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate3d()). The transitions duration will be set to 0 on window resize to avoid issues with animating while resizing.
 
-If your app uses [Velocity.js](http://julian.com/research/velocity) (included with Liquid Fire), it will be used for animating position and size. Otherwise, jQuery's [animate](http://api.jquery.com/animate) will be used.
-
 Since Links with Follower hooks in to the Router's `willTransition` event, you can use `link-to` or `transitionTo` and the follower will still update properly.
 
 ## Installation

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -221,16 +221,15 @@ export default Ember.Component.extend({
    */
   _animateFollower(animate=true, options={}) {
     let follower = this.$('.link-follower');
+    let duration = (animate) ? this.get('followerAnimationDuration') : 0;
+    let { left, width } = options;
+    let css = {
+      transform: `translate3d(${left}px, 0px, 0px)`,
+      transitionDuration: `${duration}ms`,
+      width
+    };
 
-    if (animate) {
-      if (follower.velocity) {
-        follower.velocity(options, this.get('followerAnimationDuration'));
-      } else {
-        follower.animate(options, this.get('followerAnimationDuration'));
-      }
-    } else {
-      follower.css(options);
-    }
+    follower.css(css);
   },
 
   /**

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -216,7 +216,7 @@ export default Ember.Component.extend({
    * Animates a follower to its final width / position.
    *
    * @param  {Boolean} animate=true If the follower should animate or not
-   * @param  {Object} options={}    Animate options passed to velocity or jQuery
+   * @param  {Object} options={}    Animate options passed to jQuery's css method
    * @private
    */
   _animateFollower(animate=true, options={}) {

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -216,7 +216,7 @@ export default Ember.Component.extend({
    * Animates a follower to its final width / position.
    *
    * @param  {Boolean} animate=true If the follower should animate or not
-   * @param  {Object} options={}    Animate options passed to jQuery's css method
+   * @param  {Object} options={} The animated properties, left and width, passed to jQuery's css method
    * @private
    */
   _animateFollower(animate=true, options={}) {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -9,11 +9,13 @@
   cursor: pointer;
 }
 
-.link-follower {
+.links-with-follower .link-follower {
   border-bottom: 2px solid black;
   position: absolute;
   bottom: 0;
   width: 0px;
   padding: 0 !important;
   margin: 0 !important;
+  transition: transform 150ms ease-in, width 150ms ease-in;
+  left: 0;
 }


### PR DESCRIPTION
Implements CSS transition/transform/translate3d to minimize dependency on jQuery.animate as well as [velocity.js](http://velocityjs.org/).

## Changes

- Creates a default value for the follower with `transition: transform 150ms ease-in, width 150ms ease-in;`
- Updates the private `_animateFollower` to only set the `css` of the follower and completely depend on `transition`
- Ensures that if the window is being resized the duration of the transition is set to 0

## Testing

- [x] Automated testing
- [x] Manually tested

Fixes #36 

