### PR TITLE
Adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,42 @@
+Description of PR...
+
+## Changes
+
+- Item 1
+- Item 2
+
+## API Updates
+
+### New Features *(required)*
+
+This section should include details regarding new features added to the library.
+This should include both open and private APIs. If including both, create two
+sub headers underneath this one to label updates accordingly.
+
+### Deprecations *(required)*
+
+All deprecations should be listed here in order to ensure the reviewer understands
+which sections of the codebase will affect contributors and users of the library.
+
+### Enhancements *(optional)*
+
+The enhancements section should include code updates that were included with this
+pull request. This sections should detail refactoring that might have affected
+other parts of the library.
+
+## Checklist
+
+- [ ] Unit tests
+- [ ] Documentation
+
+## References
+
+(optional)
+
+Include __important__ links regarding the implementation of this PR.
+This usually includes and RFC or an aggregation of issues and/or individual conversations
+that helped put this solution together. This helps ensure there is a good aggregation
+of resources regarding the implementation.
+
+Fixes #85, Fixes #22, Fixes username/repo#123
+Connects #123


### PR DESCRIPTION
Adds PR template from https://github.com/echobind/pr-templates/blob/master/oss/PULL_REQUEST_TEMPLATE

## Changes

- Creates a .github directory with the PR template to be used in the project

## API Updates

No API updates with this PR.

## Checklist

- [x] Unit tests
- [x] Documentation

Fixes #87 