### PR TITLE
If no active link, warn user and return immediately

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/links-with-follower';
-import { warn } from 'ember-debug';
 import { scheduleOnce, cancel, next, debounce } from 'ember-runloop';
 import { isEmpty } from 'ember-utils';
 import { assert } from 'ember-metal/utils';

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/links-with-follower';
+import { warn } from 'ember-debug';
 import { scheduleOnce, cancel, next, debounce } from 'ember-runloop';
 import { isEmpty } from 'ember-utils';
 import { assert } from 'ember-metal/utils';
@@ -183,6 +184,13 @@ export default Ember.Component.extend({
    * @private
    */
   _moveFollower(animate=true) {
+    let activeLink = this._activeLink();
+
+    if (!activeLink) {
+      warn('No active link found.', !activeLink);
+      return;
+    }
+
     let width = this._widthOfActiveLink();
     let left = this._leftPositionOfActiveLink();
     left = left + this._marginLeftOfActiveLink();

--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -186,9 +186,8 @@ export default Ember.Component.extend({
   _moveFollower(animate=true) {
     let activeLink = this._activeLink();
 
-    if (!activeLink) {
-      warn('No active link found.', !activeLink);
-      return;
+    if (activeLink.length === 0) {
+      this._hideFollower();
     }
 
     let width = this._widthOfActiveLink();

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-font-awesome": "2.2.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.1",
     "loader.js": "^4.0.10",
     "normalize.css": "^4.1.1",
     "postcss-cssnext": "^2.7.0",

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -6,10 +6,12 @@ import {
   it
 } from 'ember-mocha';
 import {
+  afterEach,
   beforeEach,
   describe
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 const {
   run
@@ -139,6 +141,8 @@ describeComponent(
     });
 
     describe('no active link', function() {
+      let sandbox;
+
       beforeEach(function() {
         this.render(hbs`
           {{#links-with-follower linkTagName='div'}}
@@ -147,6 +151,20 @@ describeComponent(
             <div>three</div>
           {{/links-with-follower}}
         `);
+
+        sandbox = sinon.sandbox.create();
+
+        sandbox.spy(Ember, 'warn');
+
+        Ember.getOwner(this).lookup('router:main').trigger('willTransition');
+      });
+
+      afterEach(function() {
+        sandbox.restore();
+      });
+
+      it('warns user that there is no active link', function() {
+        expect(Ember.warn.calledOnce).to.be.ok;
       });
 
       it('hides the follower', function() {

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -164,7 +164,7 @@ describeComponent(
       });
 
       it('warns user that there is no active link', function() {
-        expect(Ember.warn.calledOnce).to.be.ok;
+        expect(Ember.warn.called).to.be.ok;
       });
 
       it('hides the follower', function() {


### PR DESCRIPTION
This PR addresses the issue for instances where the navigation may not exist. This use case is especially for situations in which the component is hidden during a certain point in an experience.

## Changes

- Check if the active link exists, if it doesn't then we warn the developer and return immediately.
- Brings in sinon as a dev dependency to check that Ember.warn is called.

## Checklist

- [x] Unit tests
- [x] Documentation

Fixes #99 
