### PR TITLE
Check for destroyed state before moving follower

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -183,6 +183,10 @@ export default Ember.Component.extend({
    * @private
    */
   _moveFollower(animate=true) {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+    
     let activeLink = this._activeLink();
 
     if (activeLink.length === 0) {


### PR DESCRIPTION
Related to #99 - The issue here is that we are animating the follower even when the component is destroyed. This PR adds a check for the destroyed and is destroying states to the private move follower method.

## Changes

- Adds a check of isDestroying or isDestroyed state of the component to the private _moveFollower method.

## Checklist

- [x] Unit tests
- [x] Documentation
