### PR TITLE
Removes warning and sinon dependency

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -213,10 +213,6 @@ export default Ember.Component.extend({
 
     if (shouldHideFollower) {
       follower.hide();
-
-      Ember.warn('No active link found. Hiding follower', false, {
-        id: 'ember-debug.links-with-follower-no-active'
-      });
     } else {
       follower.show();
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-font-awesome": "2.2.0",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.6.0",
     "loader.js": "^4.0.10",
     "normalize.css": "^4.1.1",
     "postcss-cssnext": "^2.7.0",

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -1,17 +1,9 @@
 /* jshint expr:true */
 import Ember from 'ember';
 import { expect } from 'chai';
-import {
-  describeComponent,
-  it
-} from 'ember-mocha';
-import {
-  afterEach,
-  beforeEach,
-  describe
-} from 'mocha';
+import { describeComponent, it } from 'ember-mocha';
+import { beforeEach, describe } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
-import sinon from 'sinon';
 
 const {
   run
@@ -141,8 +133,6 @@ describeComponent(
     });
 
     describe('no active link', function() {
-      let sandbox;
-
       beforeEach(function() {
         this.render(hbs`
           {{#links-with-follower linkTagName='div'}}
@@ -152,19 +142,7 @@ describeComponent(
           {{/links-with-follower}}
         `);
 
-        sandbox = sinon.sandbox.create();
-
-        sandbox.spy(Ember, 'warn');
-
         Ember.getOwner(this).lookup('router:main').trigger('willTransition');
-      });
-
-      afterEach(function() {
-        sandbox.restore();
-      });
-
-      it('warns user that there is no active link', function() {
-        expect(Ember.warn.called).to.be.ok;
       });
 
       it('hides the follower', function() {


### PR DESCRIPTION
Removes pesky warning. No need to do a warning since the default behavior will be to hide the follower.

## Changes

- Removes warning about no active link.
- Removes ember-sinon since we no longer spy on Ember.warn

## API Updates

### New Features

N/A

### Deprecations

N/A

### Enhancements

N/A

## Checklist

- [x] Unit tests
- [ ] Documentation

Fixes #118 