### PR TITLE
Replaces getOwner polyfill for Ember.getOwner

### DIFF
--- a/addon/components/links-with-follower.js
+++ b/addon/components/links-with-follower.js
@@ -7,8 +7,11 @@ import { A as emberArray } from 'ember-array/utils';
 import { addListener, removeListener } from 'ember-metal/events';
 import computed from 'ember-computed';
 import jQuery from 'jquery';
-import getOwner from 'ember-getowner-polyfill';
 import Configuration from '../configuration';
+
+const {
+  getOwner
+} = Ember;
 
 /**
  * A component that renders a follower line underneath provided "links".

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,17 +2,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-getowner-polyfill": "1.1.1",
     "yuidoc-ember-theme": "github:offirgolan/yuidoc-ember-theme"
   },
   "ember-addon": {

--- a/tests/integration/components/links-with-follower-test.js
+++ b/tests/integration/components/links-with-follower-test.js
@@ -14,6 +14,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 const {
+  getOwner,
   run
 } = Ember;
 
@@ -156,7 +157,7 @@ describeComponent(
 
         sandbox.spy(Ember, 'warn');
 
-        Ember.getOwner(this).lookup('router:main').trigger('willTransition');
+        getOwner(this).lookup('router:main').trigger('willTransition');
       });
 
       afterEach(function() {


### PR DESCRIPTION
## Changes

- Removes `ember-getowner-polyfill` in favor of `Ember.getOwner`

## API Updates

### New Features

N/A

### Deprecations

N/A

### Enhancements

N/A

## Checklist

- [x] Unit tests
- [ ] Documentation

## References

N/A

Fixes #119 